### PR TITLE
fix: improve cover art detection for audio files without embedded cover

### DIFF
--- a/audio-stable.lua
+++ b/audio-stable.lua
@@ -296,40 +296,29 @@ function M:preload(job)
 			"-y",
 			tostring(cache_img_url),
 		}):output()
-		-- NOTE: Some audio types doesn't have cover image -> error ""
-		if
-			(
-				audio_preload_output
-				and audio_preload_output.stderr ~= nil
-				and audio_preload_output.stderr ~= ""
-				and not audio_preload_output.stderr:find("Output file.*does not contain any stream")
-			) or audio_preload_err
-		then
+		cache_img_url_cha = cache_img_url and fs.cha(cache_img_url)
+		if audio_preload_err then
 			ya.dbg("mediainfo", audio_preload_err)
-			ya.dbg("mediainfo", audio_preload_output and audio_preload_output.stderr)
 			err_msg = err_msg
 				.. string.format("Failed to start `%s`.\n Do you have `%s` installed?\n", "ffmpeg", "ffmpeg")
-		else
-			cache_img_url_cha, _ = fs.cha(cache_img_url)
-			if not cache_img_url_cha then
-				-- NOTE: Workaround case audio has no cover image. Prevent regenerate preview image
-				audio_preload_output, audio_preload_err = require("magick")
-					.with_limit()
-					:arg({
-						"-size",
-						"1x1",
-						"canvas:none",
-						string.format("PNG32:%s", cache_img_url),
-					})
-					:output()
-				if
-					(audio_preload_output and audio_preload_output.stderr ~= nil and audio_preload_output.stderr ~= "")
-					or audio_preload_err
-				then
-					ya.dbg("mediainfo", audio_preload_err or (audio_preload_output and audio_preload_output.stderr))
-					err_msg = err_msg
-						.. string.format("Failed to start `%s`.\n Do you have `%s` installed?\n", "magick", "magick")
-				end
+		elseif not cache_img_url_cha or cache_img_url_cha.len <= 0 then
+			-- NOTE: Workaround case audio has no cover image. Prevent regenerate preview image
+			audio_preload_output, audio_preload_err = require("magick")
+				.with_limit()
+				:arg({
+					"-size",
+					"1x1",
+					"canvas:none",
+					string.format("PNG32:%s", cache_img_url),
+				})
+				:output()
+			if
+				(audio_preload_output and audio_preload_output.stderr ~= nil and audio_preload_output.stderr ~= "")
+				or audio_preload_err
+			then
+				ya.dbg("mediainfo", audio_preload_err or (audio_preload_output and audio_preload_output.stderr))
+				err_msg = err_msg
+					.. string.format("Failed to start `%s`.\n Do you have `%s` installed?\n", "magick", "magick")
 			end
 		end
 	end


### PR DESCRIPTION
When previewing audio files without embedded cover art, ffmpeg exits
  successfully but produces an empty output file (stderr contains "Output
  file does not contain any stream"). The original code tried to detect
  this by pattern-matching stderr, which was fragile.

  This PR changes the logic to check the actual result:

  - Check if ffmpeg's output file exists and is non-empty via `fs.cha()`
  - Only report "ffmpeg not installed" when the command itself fails
  - Fall back to magick placeholder when the file is missing or empty (no cover)

  Fixes the "ffmpeg not installed" false-positive error when previewing
  audio files without cover art.